### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:latest AS builder
+COPY . /
+WORKDIR /
+RUN make
+
+FROM ubuntu:24.10
+LABEL Description="redis-benchmark-go"
+COPY --from=builder /redis-benchmark-go /usr/local/bin
+
+ENTRYPOINT ["redis-benchmark-go"]
+CMD [ "--help" ]


### PR DESCRIPTION
Add a Dockerfile to build a Docker image. 

Architecture will depend on the machine arch where docker build is run.