### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+<!-- TODO: one paragraph describing what this repo does -->
+
+## Local setup
+
+<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+
+```bash
+# Example
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-in-pipeline`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+
+## Running tests
+
+<!-- TODO: exact command to run tests -->
+
+```bash
+# Example
+make test
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 git clone git@github.com:redis-performance/redis-benchmark-go.git
 cd redis-benchmark-go
 
-# Fetch dependencies
-GO111MODULE=on go get -t -v ./...
+# Download module dependencies
+go mod download
 
 # Build the binary
 make build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,23 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 
 ## Project overview
 
-<!-- TODO: one paragraph describing what this repo does -->
+`redis-benchmark-go` is a Go utility (22 stars) that replicates and extends the functionality of the official `redis-benchmark` tool. It supports load-testing Redis with configurable clients, keyspace, data sizes, RPS limits, RESP2/RESP3, OSS cluster mode, MULTI/EXEC pipelines, WAIT-for-replicas, and client-side caching (CSC) via the rueidis client. The binary accepts arbitrary Redis commands with `__key__` and `__data__` placeholders and emits per-second throughput and latency percentile (p50/p95/p99) summaries. Pre-built binaries for Linux, macOS, and Windows are published on each release; Go users can also install from source.
 
 ## Local setup
 
-<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
-
 ```bash
-# Example
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
+# Clone the repo
+git clone git@github.com:redis-performance/redis-benchmark-go.git
+cd redis-benchmark-go
+
+# Fetch dependencies
+GO111MODULE=on go get -t -v ./...
+
+# Build the binary
+make build
 ```
+
+Go 1.20 or later is required. The binary will be placed in the repository root as `redis-benchmark-go`.
 
 ## Branch naming
 
@@ -26,24 +32,26 @@ Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-i
 - Prefer clear, minimal changes over large refactors unless explicitly asked.
 - Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
 - Do not introduce new dependencies without checking with the maintainer.
+- Run `make checkfmt` before committing; CI enforces `gofmt` formatting.
 
 ## Running tests
 
-<!-- TODO: exact command to run tests -->
+The test suite requires a Redis instance reachable at `localhost:6379`. Override the address with the `REDIS_TEST_HOST` environment variable (format `host:port`). Use `REDIS_TEST_PASSWORD` if authentication is needed.
 
 ```bash
-# Example
 make test
 ```
 
-Always run tests before declaring a task complete.
+`make test` fetches dependencies, builds a coverage-instrumented binary, runs `go test` with `GOCOVERDIR`, and prints a coverage summary. This is identical to what the CI workflow (`.github/workflows/build.yml`) runs.
+
+Always run `make test` before declaring a task complete.
 
 ## How to submit changes
 
 1. Create a branch: `git checkout -b <type>/<description>`.
 2. Commit with a clear message focused on *why*, not *what*.
-3. Open a pull request against `main`.
-4. Do **not** push directly to `main`.
+3. Open a pull request against `master`.
+4. Do **not** push directly to `master`.
 
 ## What to avoid
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ go mod download
 make build
 ```
 
-Go 1.20 or later is required. The binary will be placed in the repository root as `redis-benchmark-go`.
+Go 1.21 or later is required (per `go.mod`). The binary will be placed in the repository root as `redis-benchmark-go`.
 
 ## Branch naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ go mod download
 make build
 ```
 
-Go 1.20 or later is required (the project is tested against 1.20.x and 1.21.x in CI).
+Go 1.21 or later is required (per `go.mod`). CI runs the test matrix against 1.20.x and 1.21.x.
 
 ## Branch naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 git clone git@github.com:redis-performance/redis-benchmark-go.git
 cd redis-benchmark-go
 
-# Fetch dependencies
-GO111MODULE=on go get -t -v ./...
+# Download module dependencies
+go mod download
 
 # Build the binary
 make build
@@ -26,7 +26,7 @@ Go 1.20 or later is required (the project is tested against 1.20.x and 1.21.x in
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 
-Example: `feat/add-pipeline-mode`
+Example: `feat/add-rps-limit`
 
 ## Coding standards
 
@@ -47,7 +47,7 @@ Example: `feat/add-pipeline-mode`
 - All new behaviour must be covered by tests.
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
-- The test suite requires a Redis instance on `localhost:6379` (override with the `REDIS_TEST_HOST` env var).
+- The test suite requires a Redis instance on `localhost:6379`. Override with `REDIS_TEST_HOST=host:port`; use `REDIS_TEST_PASSWORD` if authentication is needed.
 
 ```bash
 # Run the full test suite (fetches deps, builds a coverage-instrumented binary, runs tests, reports coverage)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,19 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
-
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+# Clone the repo
+git clone git@github.com:redis-performance/redis-benchmark-go.git
+cd redis-benchmark-go
+
+# Fetch dependencies
+GO111MODULE=on go get -t -v ./...
+
+# Build the binary
+make build
 ```
+
+Go 1.20 or later is required (the project is tested against 1.20.x and 1.21.x in CI).
 
 ## Branch naming
 
@@ -28,12 +33,13 @@ Example: `feat/add-pipeline-mode`
 - Keep changes focused; one logical change per PR.
 - Follow the conventions already present in the codebase (formatting, naming, error handling).
 - No dead code, no commented-out blocks.
+- Run `make checkfmt` (wraps `gofmt`) before pushing; CI will reject unformatted code.
 
 ## Submitting changes
 
-1. Fork or create a branch from `main`.
+1. Fork or create a branch from `master`.
 2. Make your changes with clear, atomic commits.
-3. Open a pull request against `main` with a descriptive title and summary.
+3. Open a pull request against `master` with a descriptive title and summary.
 4. Address review comments promptly; force-push to the same branch to update.
 
 ## Testing
@@ -41,11 +47,17 @@ Example: `feat/add-pipeline-mode`
 - All new behaviour must be covered by tests.
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
+- The test suite requires a Redis instance on `localhost:6379` (override with the `REDIS_TEST_HOST` env var).
 
-<!-- TODO: add the exact test command for this repo -->
+```bash
+# Run the full test suite (fetches deps, builds a coverage-instrumented binary, runs tests, reports coverage)
+make test
+```
+
+`make test` is exactly what CI runs (see `.github/workflows/build.yml`).
 
 ## Review process
 
 - At least one maintainer approval is required before merge.
 - CI must be green.
-- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.
+- Maintainers may request changes or close PRs that do not meet the bar — this is normal and not personal.


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)