### PR TITLE
docs: add Docker usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ cd $GOPATH/src/github.com/redis-performance/redis-benchmark-go
 make
 ```
 
+## Docker
+
+Pre-built Docker images are available on Docker Hub:
+
+```bash
+docker pull redis/redis-benchmark-go:latest
+docker run --rm redis/redis-benchmark-go --help
+```
+
+Images are built for `linux/amd64` and `linux/arm64`.
+
 ## Usage of redis-benchmark-go
 
 ```


### PR DESCRIPTION
Adds Docker pull/run instructions for users who want to use the pre-built image instead of building from source.